### PR TITLE
make correct linking for english screen

### DIFF
--- a/src/screens/SettingsScreen.js
+++ b/src/screens/SettingsScreen.js
@@ -37,8 +37,7 @@ function SettingsScreen({ navigation }) {
           <Textbox bottomLine={Colors.PrimaryUtilityColor}>
             <RowLink
               title="Hilfe / FAQ"
-              onPress={() =>
-                Linking.openURL('https://fridgerio.de/hilfe')}
+              onPress={() => Linking.openURL('https://fridgerio.de/hilfe')}
             />
           </Textbox>
           <Textbox bottomLine={Colors.PrimaryUtilityColor}>
@@ -77,8 +76,7 @@ function SettingsScreen({ navigation }) {
           <Textbox bottomLine={Colors.PrimaryUtilityColor}>
             <RowLink
               title="Help / FAQ"
-              onPress={() =>
-                Linking.openURL('https://facebook.github.io/react-native/docs/linking')}
+              onPress={() => Linking.openURL('https://fridgerio.de/hilfe')}
             />
           </Textbox>
           <Textbox bottomLine={Colors.PrimaryUtilityColor}>


### PR DESCRIPTION
only the German version was linking to the right help page, the English one linked to facebook.github.io